### PR TITLE
A ruby benchmarks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,7 +112,7 @@ group :development, :test do
 
   # Preview mail in the browser instead of sending.
   # https://github.com/ryanb/letter_opener
-  gem "letter_opener"
+  gem 'letter_opener'
 end
 
 group :development do
@@ -124,5 +124,13 @@ group :development do
 
   # Detect N+1 query problems (show in the log)
   # https://github.com/flyerhzm/bullet
-  gem "bullet"
+  gem 'bullet'
+
+  # A series of things you can use to benchmark a Rails or Ruby app
+  # https://github.com/schneems/derailed_benchmarks
+  gem 'derailed_benchmarks'
+
+  # A sampling call-stack profiler
+  # https://github.com/tmm1/stackprof
+  gem 'stackprof'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,8 +48,9 @@ GEM
     autoprefixer-rails (9.4.7)
       execjs
     bcrypt (3.1.12)
+    benchmark-ips (2.7.2)
     bindex (0.5.0)
-    bootstrap-sass (3.4.0)
+    bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
     buftok (0.2.0)
@@ -69,7 +70,15 @@ GEM
     concurrent-ruby (1.1.4)
     connection_pool (2.2.2)
     crass (1.0.4)
-    devise (4.6.0)
+    derailed_benchmarks (1.3.5)
+      benchmark-ips (~> 2)
+      get_process_mem (~> 0)
+      heapy (~> 0)
+      memory_profiler (~> 0)
+      rack (>= 1)
+      rake (> 10, < 13)
+      thor (~> 0.19)
+    devise (4.6.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 6.0)
@@ -84,7 +93,7 @@ GEM
     et-orbi (1.1.7)
       tzinfo
     execjs (2.7.0)
-    factory_bot (5.0.0)
+    factory_bot (5.0.1)
       activesupport (>= 4.2.0)
     factory_bot_rails (5.0.1)
       factory_bot (~> 5.0.0)
@@ -95,6 +104,7 @@ GEM
     fugit (1.1.8)
       et-orbi (~> 1.1, >= 1.1.7)
       raabro (~> 1.1)
+    get_process_mem (0.2.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.0.4)
@@ -106,6 +116,7 @@ GEM
       haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
+    heapy (0.1.4)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -144,6 +155,7 @@ GEM
       mimemagic (~> 0.3.2)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
+    memory_profiler (0.9.12)
     method_source (0.9.2)
     mimemagic (0.3.3)
     mini_mime (1.0.1)
@@ -251,8 +263,8 @@ GEM
     sexp_processor (4.11.0)
     shoulda-callback-matchers (1.1.4)
       activesupport (>= 3)
-    shoulda-matchers (3.1.3)
-      activesupport (>= 4.0.0)
+    shoulda-matchers (4.0.0)
+      activesupport (>= 4.2.0)
     sidekiq (5.2.5)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (>= 1.5.0)
@@ -271,6 +283,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    stackprof (0.2.12)
     temple (0.8.0)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
@@ -320,6 +333,7 @@ DEPENDENCIES
   bootstrap-sass
   bullet
   coffee-rails
+  derailed_benchmarks
   devise
   factory_bot_rails
   haml-rails
@@ -343,6 +357,7 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq-cron
   spring
+  stackprof
   therubyracer
   time_difference
   twitter


### PR DESCRIPTION
For example `bundle exec derailed bundle:mem`

```
TOP: 61.3242 MiB
  rails/all: 25.8086 MiB
    rails: 12.168 MiB (Also required by: active_record/railtie, active_model/railtie, and 10 others)
      rails/application: 4.4414 MiB
        active_support/key_generator: 2.9922 MiB
          openssl: 2.9922 MiB (Also required by: active_support/message_encryptor, redis, and 5 others)
            openssl.so: 2.082 MiB
              digest.so: 0.9375 MiB
            openssl/ssl: 0.9102 MiB
              ipaddr: 0.5156 MiB (Also required by: pg/text_encoder, raven/utils/real_ip)
                socket: 0.5156 MiB (Also required by: raven/event, redis, and 7 others)
        yaml: 0.6797 MiB (Also required by: active_support/encrypted_configuration, rails/secrets, and 3 others)
          psych: 0.6797 MiB
        active_support/message_verifier: 0.5195 MiB (Also required by: active_support/message_encryptor)
          active_support/security_utils: 0.5195 MiB
            digest/sha2: 0.5195 MiB (Also required by: active_record/connection_adapters/abstract/schema_statements, sprockets/digest_utils)
              digest/sha2.so: 0.5195 MiB
      active_support: 3.9688 MiB (Also required by: active_support/railtie, active_support/i18n_railtie, and 15 others)
        active_support/logger: 2.0703 MiB
          active_support/logger_silence: 2.0703 MiB
            concurrent: 2.0703 MiB (Also required by: sprockets/manifest)
              concurrent/configuration: 1.0313 MiB (Also required by: concurrent/scheduled_task, concurrent/options, and 2 others)
                concurrent/delay: 0.7734 MiB (Also required by: concurrent/utility/processor_counter, concurrent)
                  concurrent/executor/immediate_executor: 0.5156 MiB (Also required by: concurrent/configuration, concurrent/executors)
                    concurrent/executor/abstract_executor_service: 0.5156 MiB (Also required by: concurrent/executor/ruby_executor_service, concurrent/executors)
        active_support/dependencies/autoload: 1.6406 MiB (Also required by: rails, active_support/rails)
          active_support/inflector/methods: 1.6406 MiB (Also required by: active_support/inflector, active_support/core_ext/string/inflections, and 3 others)
            active_support/inflections: 1.6406 MiB (Also required by: active_support/inflector)
              active_support/inflector/inflections: 1.6406 MiB (Also required by: active_support/inflector)
                active_support/deprecation: 0.7695 MiB (Also required by: rails/application, active_support/duration, and 2 others)
                active_support/i18n: 0.5156 MiB (Also required by: active_support/inflector/transliterate, abstract_controller)
                  i18n: 0.5156 MiB
      active_support/railtie: 3.5 MiB
        active_support/i18n_railtie: 3.5 MiB
          active_support/file_update_checker: 2.8359 MiB (Also required by: rails/application/configuration)
            active_support/core_ext/time/calculations: 2.8359 MiB (Also required by: active_support/core_ext/time, active_support/core_ext/numeric/time)
              active_support/core_ext/time/conversions: 1.8047 MiB (Also required by: active_support/core_ext/time, active_support/core_ext/date_time/conversions)
                active_support/values/time_zone: 1.8047 MiB (Also required by: active_support/time_with_zone, active_support/core_ext/date_time/conversions)
                  tzinfo: 1.5469 MiB (Also required by: et-orbi)
                    tzinfo/timezone: 0.5156 MiB
              active_support/duration: 0.5156 MiB (Also required by: active_support/time_with_zone, active_support/core_ext/date/calculations, and 2 others)
          rails/railtie/configuration: 0.6641 MiB (Also required by: rails/engine/configuration)
            rails/configuration: 0.6641 MiB
              active_support/core_ext/object: 0.4063 MiB
    sprockets/railtie: 5.0938 MiB (Also required by: sass/rails/railtie)
      sprockets/rails/context: 3.793 MiB
        action_view/helpers: 3.793 MiB
          action_view/helpers/form_helper: 3.2773 MiB (Also required by: action_view/helpers/form_options_helper)
            action_view/helpers/form_tag_helper: 3.2773 MiB
              action_view/helpers/text_helper: 3.2773 MiB
                action_view/helpers/sanitize_helper: 3.2773 MiB
                  rails-html-sanitizer: 3.2773 MiB
                    loofah: 3.2773 MiB
                      nokogiri: 2.707 MiB
                        nokogiri/xml: 1.5938 MiB
                          nokogiri/xml/parse_options: 1.3359 MiB
                        nokogiri/html: 0.7734 MiB
                          nokogiri/html/element_description_defaults: 0.5156 MiB
                      loofah/html5/libxml2_workarounds: 0.5703 MiB
      sprockets: 1.0469 MiB (Also required by: sprockets/rails/context, sprockets/rails/helper)
    active_record/railtie: 4.3047 MiB
      active_record: 2.5 MiB (Also required by: active_storage, orm_adapter/adapters/active_record)
        active_record/connection_adapters/abstract_adapter: 1.2188 MiB
          active_record/connection_adapters/abstract/schema_statements: 0.3945 MiB
            active_record/migration/join_table: 0.3945 MiB
              active_record/migration: 0.3945 MiB
        arel: 0.7656 MiB
          arel/visitors: 0.5156 MiB
      action_controller/railtie: 1.8047 MiB (Also required by: rails/all, sprockets/railtie)
        action_controller: 1.2891 MiB (Also required by: responders)
          action_controller/metal/live: 0.7734 MiB
            action_dispatch/http/response: 0.7734 MiB
              rack/response: 0.5156 MiB
                rack/request: 0.5156 MiB (Also required by: action_dispatch/http/request)
                  rack/utils: 0.5156 MiB (Also required by: rack/response, sprockets/server, and 3 others)
          action_controller/metal/strong_parameters: 0.5156 MiB
        action_view/railtie: 0.5156 MiB (Also required by: rails/all)
          action_view: 0.5156 MiB (Also required by: sprockets/rails/helper)
            active_support/core_ext/string/output_safety: 0.5156 MiB (Also required by: action_view/helpers/tag_helper, action_view/helpers/capture_helper, and 7 others)
    active_storage/engine: 2.6953 MiB
      action_dispatch/routing/route_set: 2.1797 MiB
        action_dispatch/http/request: 1.0313 MiB (Also required by: action_dispatch/routing/redirection)
        action_dispatch/journey: 0.8906 MiB
          action_dispatch/journey/router: 0.375 MiB
      active_storage/analyzer/video_analyzer: 0.5156 MiB
    rails/test_unit/railtie: 0.7734 MiB
      rails/test_unit/line_filtering: 0.7734 MiB
        rails/test_unit/runner: 0.7734 MiB
          rake/file_list: 0.5156 MiB (Also required by: rake/application, rake)
    action_mailer/railtie: 0.5156 MiB
      active_job/railtie: 0.5156 MiB (Also required by: rails/all)
        global_id/railtie: 0.5156 MiB
  twitter: 9.9414 MiB
    twitter/cursor: 3.5195 MiB (Also required by: twitter/rest/utils, twitter/rest/friends_and_followers, and 2 others)
      twitter/rest/request: 3.5195 MiB (Also required by: twitter/rest/utils, twitter/rest/friends_and_followers, and 8 others)
        http: 3.4414 MiB (Also required by: twitter/streaming/response)
          http/response: 2.6211 MiB
            http/cookie_jar: 2.6211 MiB
              http/cookie: 2.6211 MiB
                domain_name: 2.6211 MiB
                  domain_name/etld_data: 2.6211 MiB
          http/client: 0.7891 MiB (Also required by: http/response/body)
            http/options: 0.5156 MiB (Also required by: http)
    twitter/rest/client: 2.0625 MiB
      twitter/rest/api: 2.0625 MiB
        twitter/rest/direct_messages: 0.5156 MiB
          twitter/rest/utils: 0.5156 MiB (Also required by: twitter/rest/favorites, twitter/rest/friends_and_followers, and 13 others)
    addressable/uri: 1.6055 MiB (Also required by: twitter/base, twitter/rest/request, and 6 others)
      addressable/idna: 0.7734 MiB
        addressable/idna/pure: 0.7734 MiB
    twitter/streaming/client: 1.2891 MiB
      twitter/streaming/connection: 1.2891 MiB
        resolv: 1.2891 MiB (Also required by: new_relic/agent)
    twitter/direct_message: 0.5156 MiB (Also required by: twitter/rest/direct_messages, twitter/streaming/message_parser)
      twitter/entities: 0.5156 MiB (Also required by: twitter/tweet)
        twitter/media_factory: 0.5156 MiB (Also required by: twitter)
  sass-rails: 5.9727 MiB
    sass/rails: 5.9727 MiB
      sass/rails/helpers: 5.9727 MiB (Also required by: sass/rails/template)
        sass: 5.9727 MiB (Also required by: sass/rails/importer, sass/rails/template, and 3 others)
          sass/engine: 5.2031 MiB
            sass/script: 1.2891 MiB (Also required by: sass/script/css_parser)
              sass/script/functions: 1.0313 MiB (Also required by: sass/script/tree/funcall)
            sass/selector: 0.5156 MiB
          sass/version: 0.7695 MiB
            sass/util: 0.7695 MiB (Also required by: sass, sass/script/tree/funcall)
  uglifier: 5.0625 MiB
    execjs: 5.0625 MiB (Also required by: coffee_script)
  pg: 3.4922 MiB
    pg_ext: 3.4922 MiB
  newrelic_rpm: 2.875 MiB
    new_relic/control: 2.875 MiB
      new_relic/agent: 2.8477 MiB
        new_relic/agent/agent: 2.0625 MiB
          new_relic/agent/configuration/manager: 1.0313 MiB (Also required by: new_relic/agent/configuration)
            new_relic/agent/configuration/default_source: 1.0313 MiB
        new_relic/agent/cross_app_monitor: 0.5273 MiB (Also required by: new_relic/agent/agent)
          new_relic/agent/tracer: 0.5273 MiB
  devise: 2.3203 MiB
    warden: 0.5156 MiB
    devise/rails: 0.5156 MiB
      devise/rails/routes: 0.5156 MiB
        action_dispatch/routing/mapper: 0.5156 MiB
  sentry-raven: 1.957 MiB
    raven: 1.957 MiB
      raven/integrations/sidekiq: 1.4414 MiB
        sidekiq: 1.4414 MiB (Also required by: sidekiq-cron, sidekiq/cron/job, and 5 others)
          sidekiq/redis_connection: 1.2813 MiB
            redis: 1.0313 MiB
  haml-rails: 1.3164 MiB
    haml: 1.3164 MiB
      haml/engine: 1.3164 MiB
        haml/compiler: 0.8008 MiB
          haml/attribute_compiler: 0.8008 MiB
            haml/attribute_parser: 0.8008 MiB
              ripper: 0.8008 MiB
                ripper/sexp: 0.6641 MiB
  rufus-scheduler: 1.0313 MiB
    rufus/scheduler: 1.0313 MiB
      fugit: 0.7734 MiB (Also required by: sidekiq/cron/job)
        fugit/cron: 0.5156 MiB
  jbuilder: 0.7734 MiB
    jbuilder/railtie: 0.5156 MiB
      jbuilder/jbuilder_template: 0.5156 MiB
  sidekiq-cron: 0.5156 MiB
    sidekiq/cron: 0.5156 MiB (Also required by: sidekiq/cron/poller)
```