### PR TITLE
Remove newrelic in favor of memory leaks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,9 +60,6 @@ gem 'liblinear-ruby'
 # https://github.com/javan/whenever/
 gem 'whenever', :require => false
 
-# New Relic
-gem 'newrelic_rpm'
-
 # Applies a patch to OpenURI to optionally allow redirections from HTTP to HTTPS
 # https://github.com/open-uri-redirections/open_uri_redirections
 gem 'open_uri_redirections'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,6 @@ GEM
     multi_json (1.13.1)
     multipart-post (2.0.0)
     naught (1.1.0)
-    newrelic_rpm (6.0.0.351)
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
@@ -341,7 +340,6 @@ DEPENDENCIES
   jquery-rails
   letter_opener
   liblinear-ruby
-  newrelic_rpm
   open_uri_redirections
   pg (>= 0.18, < 2.0)
   pry-rails


### PR DESCRIPTION
The New Relic is not used and this save memory